### PR TITLE
No need to quote strings as tags. spaces are separated by a backslash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 .DS_Store
+.idea/

--- a/lib/infludp/client.rb
+++ b/lib/infludp/client.rb
@@ -13,23 +13,34 @@ module Infludp
 
     def send(name, tags, fields)
       socket.send(
-        build_metric(name, tags, fields),
-        0,
-        host,
-        port
+          build_metric(name, tags, fields),
+          0,
+          host,
+          port
       )
     end
 
     def build_metric(name, tags, fields)
-      "#{name},#{to_line(tags)} #{to_line(fields)}"
+      "#{name},#{to_tag_line(tags)} #{to_field_line(fields)}"
     end
 
-    def to_line(hash)
+    def to_field_line(hash)
       hash.map do |key, value|
         if value.is_a?(String)
           "#{key}=\"#{value}\""
         else
           "#{key}=#{value}"
+        end
+      end.join(',')
+    end
+
+    def to_tag_line(hash)
+      hash.map do |key, value|
+        str_value = value.to_s
+        if str_value.match?(/\s/)
+          "#{key}=#{str_value.gsub(/ /, '\ ')}"
+        else
+          "#{key}=#{str_value}"
         end
       end.join(',')
     end

--- a/lib/infludp/version.rb
+++ b/lib/infludp/version.rb
@@ -1,3 +1,3 @@
 module Infludp
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end

--- a/test/spec/client_spec.rb
+++ b/test/spec/client_spec.rb
@@ -15,7 +15,7 @@ describe 'InfluxDB UDP client' do
   it 'can build a line protocol from a hash' do
     fields = {value: 13, temperature: 12, sensor: 'left'}
     line = 'value=13,temperature=12,sensor="left"'
-    @client.to_line(fields).must_equal line
+    @client.to_field_line(fields).must_equal line
   end
 
   it 'can send a metric via UDP' do
@@ -28,7 +28,7 @@ describe 'InfluxDB UDP client' do
       value: 22
     }
 
-    expected = 'cpu,node="server1",os="ubuntu" value=22'
+    expected = 'cpu,node=server1,os=ubuntu value=22'
 
     reader, writer = IO.pipe
 


### PR DESCRIPTION
before:
```
> select * from worker_filter
name: worker_filter
time                id score status value
----                -- ----- ------ -----
1528364600014693922 "1"  3     "sent"   1
```
The line protocol indicates that tag values are always strings and they don't have to be quoted. [source](https://docs.influxdata.com/influxdb/v1.5/write_protocols/line_protocol_tutorial/)
This PR fixes the quotes removing them:
```
> select * from worker_filter
name: worker_filter
time                id score status value
----                -- ----- ------ -----
1528364600014693922 1  3     sent   1
```

Tests have been refactored and they are passing